### PR TITLE
Only interact with urlSchemeRequestTasks dictionary on main thread

### DIFF
--- a/ios/RNCWKSchemeHandler.m
+++ b/ios/RNCWKSchemeHandler.m
@@ -25,9 +25,33 @@
   self.session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:nil];
 
   // Set up a map for saving tasks.
+  // This and it's objects should only be mutated on the main thread.
   self.urlSchemeRequestTasks = [[NSMutableDictionary alloc] init];
 
   return self;
+}
+
+-(NSString *)setSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
+  // Save the task in a NSMutableDictionary.
+  // NSMutableDictionary is not thread safe, so only perform mutating
+  // operations on it on the main thread.
+  NSString* requestId = [NSString stringWithFormat:@"%p", urlSchemeTask];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self.urlSchemeRequestTasks setObject:urlSchemeTask forKey:requestId];
+  });
+
+  return requestId;
+}
+
+-(void)removeSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
+  NSString* requestId = [NSString stringWithFormat:@"%p", urlSchemeTask];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [self.urlSchemeRequestTasks removeObjectForKey:requestId];
+  });
+}
+
+-(id <WKURLSchemeTask>)getSchemeTaskForID:(NSString *)requestID {
+  return [self.urlSchemeRequestTasks objectForKey:requestID];
 }
 
 -(void)URLSession:(NSURLSession *)session
@@ -38,6 +62,7 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
   completionHandler(nil);
 }
 
+// Note: WebKit calls this on the main thread.
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
 
   // Get request data. For whatever reason, the body data isnt available.
@@ -46,9 +71,8 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
   NSString* method = [urlSchemeTask request].HTTPMethod;
   NSDictionary* headers = urlSchemeTask.request.allHTTPHeaderFields;
 
-  // Save the task in a map.
-  NSString* requestId = [NSString stringWithFormat:@"%p", urlSchemeTask];
-  [self.urlSchemeRequestTasks setObject:urlSchemeTask forKey:requestId];
+  // Save the scheme task in our dictionary
+  NSString* requestId = [self setSchemeTask: urlSchemeTask];
 
   // Package up all the information for the JS event.
   NSDictionary *req = @{
@@ -60,19 +84,22 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
 
   // Send off to React Native.
   [self.delegate handleUrlSchemeRequest:req];
-
 }
 
 - (void)handleUrlSchemeResponse:(NSDictionary *)resp
 {
   // Grab the task we want to complete.
   NSString *requestId = [resp objectForKey:@"requestId"];
-  id<WKURLSchemeTask> urlSchemeTask = [self.urlSchemeRequestTasks objectForKey:requestId];
+  id<WKURLSchemeTask> urlSchemeTask = [self getSchemeTaskForID:requestId];
   if (!urlSchemeTask) {
     return;
   }
 
   NSString *type = [resp objectForKey:@"type"];
+  if (!type) {
+    NSLog(@"schemeResponse does not have object with key 'type'");
+    return;
+  }
 
   if ([type isEqualToString:@"response"]) {
     NSString *url = [resp objectForKey:@"url"];
@@ -99,30 +126,31 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
 
     NSURL *requestUrl = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"file://%@", file]];
     NSURL *responseUrl = [[NSURL alloc] initWithString:url];
-
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:requestUrl
                                                                 cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
                                                             timeoutInterval:60.0];
 
     NSURLSessionDataTask* requestTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+      // NSMutableDictionary is not thread safe, so any interaction with it or it's objects should be done on the main thread.
+      dispatch_async(dispatch_get_main_queue(), ^{
+        id<WKURLSchemeTask> urlSchemeTask = [self getSchemeTaskForID:requestId];
+        if (!urlSchemeTask) {
+          return;
+        }
 
-      id<WKURLSchemeTask> urlSchemeTask = [self.urlSchemeRequestTasks objectForKey:requestId];
-      if (!urlSchemeTask) {
-        return;
-      }
+        if (response) {
+          // Need to respond with the responseUrl, not the requestUrl or else the WebView is unhappy.
+          // Also need to respond with the response headers specifying the content type.
+          NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+          NSHTTPURLResponse* proxyResponse = [[NSHTTPURLResponse alloc] initWithURL:responseUrl statusCode:httpResponse.statusCode HTTPVersion:@"HTTP/2" headerFields:headers];
 
-      if (response) {
-        // Need to respond with the responseUrl, not the requestUrl or else the WebView is unhappy.
-        // Also need to respond with the response headers specifying the content type.
-        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-        NSHTTPURLResponse* proxyResponse = [[NSHTTPURLResponse alloc] initWithURL:responseUrl statusCode:httpResponse.statusCode HTTPVersion:@"HTTP/2" headerFields:headers];
-
-        [urlSchemeTask didReceiveResponse: proxyResponse];
-        [urlSchemeTask didReceiveData:data];
-        [urlSchemeTask didFinish];
-      } else if (error) {
-        [urlSchemeTask didFailWithError:error];
-      }
+          [urlSchemeTask didReceiveResponse: proxyResponse];
+          [urlSchemeTask didReceiveData:data];
+          [urlSchemeTask didFinish];
+        } else if (error) {
+          [urlSchemeTask didFailWithError:error];
+        }
+      });
     }];
 
     [requestTask resume];
@@ -146,31 +174,32 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
     }
 
     NSURLSessionDataTask* requestTask = [self.session dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        id<WKURLSchemeTask> urlSchemeTask = [self getSchemeTaskForID:requestId];
+        if (!urlSchemeTask) {
+          return;
+        }
 
-      id<WKURLSchemeTask> urlSchemeTask = [self.urlSchemeRequestTasks objectForKey:requestId];
-      if (!urlSchemeTask) {
-        return;
-      }
+        if (response) {
+          NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
+          NSHTTPURLResponse* proxyResponse = [[NSHTTPURLResponse alloc] initWithURL:requestUrl statusCode:httpResponse.statusCode HTTPVersion:@"HTTP/2" headerFields:[httpResponse allHeaderFields]];
 
-      if (response) {
-        NSHTTPURLResponse* httpResponse = (NSHTTPURLResponse*)response;
-        NSHTTPURLResponse* proxyResponse = [[NSHTTPURLResponse alloc] initWithURL:requestUrl statusCode:httpResponse.statusCode HTTPVersion:@"HTTP/2" headerFields:[httpResponse allHeaderFields]];
-
-        [urlSchemeTask didReceiveResponse: proxyResponse];
-        [urlSchemeTask didReceiveData:data];
-        [urlSchemeTask didFinish];
-      } else if (error) {
-        [urlSchemeTask didFailWithError:error];
-      }
+          [urlSchemeTask didReceiveResponse: proxyResponse];
+          [urlSchemeTask didReceiveData:data];
+          [urlSchemeTask didFinish];
+        } else if (error) {
+          [urlSchemeTask didFailWithError:error];
+        }
+      });
     }];
 
     [requestTask resume];
   }
 }
 
+// Note: WebKit calls this on the main thread.
 - (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
-  NSString* requestId = [NSString stringWithFormat:@"%p", urlSchemeTask];
-  [self.urlSchemeRequestTasks removeObjectForKey:requestId];
+  [self removeSchemeTask:urlSchemeTask];
 }
 
 @end

--- a/ios/RNCWKSchemeHandler.m
+++ b/ios/RNCWKSchemeHandler.m
@@ -31,11 +31,15 @@
   return self;
 }
 
+-(NSString *)identifierForSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
+  return [NSString stringWithFormat:@"%p", urlSchemeTask];
+}
+
 -(NSString *)setSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
   // Save the task in a NSMutableDictionary.
   // NSMutableDictionary is not thread safe, so only perform mutating
   // operations on it on the main thread.
-  NSString* requestId = [NSString stringWithFormat:@"%p", urlSchemeTask];
+  NSString* requestId = [self identifierForSchemeTask:urlSchemeTask];
   dispatch_async(dispatch_get_main_queue(), ^{
     [self.urlSchemeRequestTasks setObject:urlSchemeTask forKey:requestId];
   });
@@ -44,10 +48,11 @@
 }
 
 -(void)removeSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
-  NSString* requestId = [NSString stringWithFormat:@"%p", urlSchemeTask];
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [self.urlSchemeRequestTasks removeObjectForKey:requestId];
-  });
+  if (urlSchemeTask) {
+     dispatch_async(dispatch_get_main_queue(), ^{
+      [self.urlSchemeRequestTasks removeObjectForKey:[self identifierForSchemeTask:urlSchemeTask]];
+    });
+  }
 }
 
 -(id <WKURLSchemeTask>)getSchemeTaskForID:(NSString *)requestID {


### PR DESCRIPTION
Task: https://dev.notion.so/notion/iOS-app-crashes-while-editing-long-page-28ab6dbf51154e56a9e530eab3d940fd

This fixes a crash where `WKURLSchemeTasks` would have messages sent to them after they had been finished by WebKit, thereby throwing an exception.

WebKit starts these tasks on the `main` thread and also will say when it has stopped tasks also on `main`. 

The code currently stores the tasks in `NSMutableDictionary` which is *not* thread safe. The dictionary is accessed in request block callback and fields are set there and the task is set to finished or an error state.

This wraps the getters and setters to `urlSchemeRequestTasks` to only operate on the main thread. As well as in the callbacks that deal with the `WKURLSchemeTasks` it holds.

### Places where WebKit cancels tasks

`WebProcess` → `WebProcess::networkProcessConnectionClosed()`→ loops through all pages and calls `page->stopAllURLSchemeTasks()` → Loop over handlers and calls stopAllTasksForPage()

`WebPageProxy::processDidTerminate()` → `stopAllURLSchemeTasks()`→ Loop over handlers and calls `stopAllTasksForPage()`

`stopAllURLSchemeTasks()` is also called when `WebView` is deallocated.

https://git.webkit.org/?p=WebKit.git&a=search&h=refs%2Fheads%2Fmaster&st=grep&s=stopAllURLSchemeTasks%28%29