### PR TITLE
Serialize access to `urlSchemeRequestTasks` and remove tasks once done

### DIFF
--- a/ios/RNCWKSchemeHandler.m
+++ b/ios/RNCWKSchemeHandler.m
@@ -31,31 +31,25 @@
   return self;
 }
 
--(NSString *)identifierForSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
+-(NSString *)identifierForSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask API_AVAILABLE(ios(11.0)){
   return [NSString stringWithFormat:@"%p", urlSchemeTask];
 }
 
--(NSString *)setSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
+-(NSString *)setSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask API_AVAILABLE(ios(11.0)){
   // Save the task in a NSMutableDictionary.
   // NSMutableDictionary is not thread safe, so only perform mutating
   // operations on it on the main thread.
   NSString* requestId = [self identifierForSchemeTask:urlSchemeTask];
-  dispatch_async(dispatch_get_main_queue(), ^{
-    [self.urlSchemeRequestTasks setObject:urlSchemeTask forKey:requestId];
-  });
+  [self.urlSchemeRequestTasks setObject:urlSchemeTask forKey:requestId];
 
   return requestId;
 }
 
--(void)removeSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
-  if (urlSchemeTask) {
-     dispatch_async(dispatch_get_main_queue(), ^{
-      [self.urlSchemeRequestTasks removeObjectForKey:[self identifierForSchemeTask:urlSchemeTask]];
-    });
-  }
+-(void)removeSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask API_AVAILABLE(ios(11.0)){
+  [self.urlSchemeRequestTasks removeObjectForKey:[self identifierForSchemeTask:urlSchemeTask]];
 }
 
--(id <WKURLSchemeTask>)getSchemeTaskForID:(NSString *)requestID {
+-(id <WKURLSchemeTask>)getSchemeTaskForID:(NSString *)requestID API_AVAILABLE(ios(11.0)){
   return [self.urlSchemeRequestTasks objectForKey:requestID];
 }
 
@@ -68,7 +62,7 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
 }
 
 // Note: WebKit calls this on the main thread.
-- (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask {
+- (void)webView:(WKWebView *)webView startURLSchemeTask:(id <WKURLSchemeTask>)urlSchemeTask API_AVAILABLE(ios(11.0)){
 
   // Get request data. For whatever reason, the body data isnt available.
   // https://bugs.webkit.org/show_bug.cgi?id=180220
@@ -77,7 +71,7 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
   NSDictionary* headers = urlSchemeTask.request.allHTTPHeaderFields;
 
   // Save the scheme task in our dictionary
-  NSString* requestId = [self setSchemeTask: urlSchemeTask];
+  NSString* requestId = [self setSchemeTask:urlSchemeTask];
 
   // Package up all the information for the JS event.
   NSDictionary *req = @{
@@ -91,7 +85,7 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
   [self.delegate handleUrlSchemeRequest:req];
 }
 
-- (void)handleUrlSchemeResponse:(NSDictionary *)resp
+- (void)handleUrlSchemeResponse:(NSDictionary *)resp API_AVAILABLE(ios(11.0))
 {
   // Grab the task we want to complete.
   NSString *requestId = [resp objectForKey:@"requestId"];
@@ -124,6 +118,7 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
     }
 
     [urlSchemeTask didFinish];
+    [self removeSchemeTask:urlSchemeTask];
   } else if ([type isEqualToString:@"file"]) {
     NSString *url = [resp objectForKey:@"url"];
     NSString *file = [resp objectForKey:@"file"];
@@ -155,6 +150,7 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
         } else if (error) {
           [urlSchemeTask didFailWithError:error];
         }
+        [self removeSchemeTask:urlSchemeTask];
       });
     }];
 
@@ -195,6 +191,8 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
         } else if (error) {
           [urlSchemeTask didFailWithError:error];
         }
+
+        [self removeSchemeTask:urlSchemeTask];
       });
     }];
 
@@ -203,7 +201,7 @@ completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler {
 }
 
 // Note: WebKit calls this on the main thread.
-- (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
+- (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask API_AVAILABLE(ios(11.0)){
   [self removeSchemeTask:urlSchemeTask];
 }
 


### PR DESCRIPTION
### Background
Fixes from last week made all operations happen on `main` thread and the assumption was it should fix the multi-threading crashes. Latest iOS app still has crashes. What is going on?
https://fabric.io/notion6/ios/apps/notion.id/issues?time=last-twenty-four-hours&event_type=all&subFilter=state&state=open&build%5B0%5D=0.4.18%20%281%29

### Theory
We have moved all operations to `main` thread and so did the crashes. We know that they happen in our code which means that writes to `WKURLSchemeTask` happen after OS has already called `stopURLSchemeTask` and stopped the task. But wait, aren't we removing the `urlSchemeTask` from `urlSchemeRequestTasks` dictionary when `stopURLSchemeTask` is called? Not only that, we're also doing on it on `main` thread, so we should be good! It seems that we do indeed call it on `main` thread but that actually brakes the atomicity of the operation since `stopURLSchemeTask` is already being called on main thread. What follows is 1) `stopURLSchemeTask` gets called and task gets stopped 2) Meanwhile, `dispatch_async` inside `handleUrlSchemeResponse` queues operation that crashes on main thread 3) finally `stopURLSchemeTask` queues the call inside `removeSchemeTask` on the main thread as well. In this case the task has been stopped but not removed from the dictionary. The callback from 2) still finds the task in the dictionary and acts on it, even though it shouldn't.

### Fix
Since `stopURLSchemeTask` runs on `main` thread anyway, we don't need to enqueue the removal from dictionary as a separate operation and can do it in the same call stack. How do we know that it runs on `main` thread? The commit to `WebKit` below.
https://github.com/WebKit/webkit/commit/c2d746f2986daf015db8827619e4db6efa702334
